### PR TITLE
Remove explicit success getter

### DIFF
--- a/src/test/java/com/uplatform/wallet_tests/api/redis/client/CheckResult.java
+++ b/src/test/java/com/uplatform/wallet_tests/api/redis/client/CheckResult.java
@@ -8,8 +8,4 @@ import lombok.Data;
 public class CheckResult {
     private boolean success;
     private String message;
-
-    public boolean isSuccess() {
-        return success;
-    }
 }


### PR DESCRIPTION
## Summary
- rely on Lombok to generate `isSuccess()` in `CheckResult`

## Testing
- `gradle test` *(fails: Plugin not found, no network access)*

------
https://chatgpt.com/codex/tasks/task_e_687bb3757ccc832fb1a5ac5b2b9138bf