### PR TITLE
Refactor Redis clients with generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ step("Kafka: получение сообщения", () -> {
 `getWithCheck` для извлечения данных с повторами через `RedisRetryHelper` и
 автоматически формирует аттачи в Allure при каждом обращении. Конкретные
 клиенты, например `PlayerRedisClient` и `WalletRedisClient`, лишь расширяют
-его и реализуют методы для своих ключей.
+его и реализуют методы для своих ключей. Абстракция принимает тип значения
+как параметр и хранит `TypeReference<T>` в конструкторе, поэтому тип
+десериализации не нужно указывать при каждом вызове.
 
 ### 2. Как настроить подключение
 
@@ -393,18 +395,19 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.stereotype.Component;
 
 @Component
-public class BonusRedisClient extends AbstractRedisClient {
+public class BonusRedisClient extends AbstractRedisClient<BonusAggregate> {
 
     public BonusRedisClient(
             @Qualifier("bonusRedisTemplate") RedisTemplate<String, String> template,
             RedisRetryHelper retryHelper,
             AllureAttachmentService attachmentService
     ) {
-        super("BONUS", template, retryHelper, attachmentService);
+        super("BONUS", template, retryHelper, attachmentService,
+                new TypeReference<BonusAggregate>() {});
     }
 
     public BonusAggregate getBonus(String key) {
-        return getWithRetry(key, new TypeReference<BonusAggregate>() {});
+        return getWithRetry(key);
     }
 }
 ```

--- a/src/test/java/com/uplatform/wallet_tests/api/redis/client/PlayerRedisClient.java
+++ b/src/test/java/com/uplatform/wallet_tests/api/redis/client/PlayerRedisClient.java
@@ -1,10 +1,10 @@
 package com.uplatform.wallet_tests.api.redis.client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.uplatform.wallet_tests.api.redis.exception.RedisClientException;
 import com.uplatform.wallet_tests.api.redis.model.WalletData;
 import com.uplatform.wallet_tests.api.redis.model.WalletFilterCriteria;
 import com.uplatform.wallet_tests.api.attachment.AllureAttachmentService;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -16,12 +16,13 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 @Slf4j
-public class PlayerRedisClient extends AbstractRedisClient {
+public class PlayerRedisClient extends AbstractRedisClient<Map<String, WalletData>> {
 
     public PlayerRedisClient(@Qualifier("playerRedisTemplate") RedisTemplate<String, String> redisTemplate,
                              RedisRetryHelper retryHelper,
                              AllureAttachmentService attachmentService) {
-        super("PLAYER", redisTemplate, retryHelper, attachmentService);
+        super("PLAYER", redisTemplate, retryHelper, attachmentService,
+                new TypeReference<Map<String, WalletData>>() {});
     }
 
     private boolean matchesCriteria(WalletData wallet, WalletFilterCriteria criteria) {
@@ -37,7 +38,6 @@ public class PlayerRedisClient extends AbstractRedisClient {
         if (playerId == null) { throw new RedisClientException("[PLAYER] Cannot get wallet: playerId is null."); }
         if (criteria == null) { throw new RedisClientException("[PLAYER] Cannot get wallet: criteria is null."); }
 
-        TypeReference<Map<String, WalletData>> mapTypeRef = new TypeReference<>() {};
         String criteriaDesc = describeCriteria(criteria);
 
         BiFunction<Map<String, WalletData>, String, CheckResult> checkMapAndCriteria = (walletsMap, rawJson) -> {
@@ -52,7 +52,7 @@ public class PlayerRedisClient extends AbstractRedisClient {
             }
         };
 
-        Map<String, WalletData> walletsMapResult = getWithCheck(playerId, mapTypeRef, checkMapAndCriteria);
+        Map<String, WalletData> walletsMapResult = getWithCheck(playerId, checkMapAndCriteria);
 
         Optional<WalletData> foundWallet = walletsMapResult.values().stream()
                 .filter(wallet -> matchesCriteria(wallet, criteria))

--- a/src/test/java/com/uplatform/wallet_tests/api/redis/client/WalletRedisClient.java
+++ b/src/test/java/com/uplatform/wallet_tests/api/redis/client/WalletRedisClient.java
@@ -12,12 +12,13 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 @Slf4j
-public class WalletRedisClient extends AbstractRedisClient {
+public class WalletRedisClient extends AbstractRedisClient<WalletFullData> {
 
     public WalletRedisClient(@Qualifier("walletRedisTemplate") RedisTemplate<String, String> redisTemplate,
                              RedisRetryHelper retryHelper,
                              AllureAttachmentService attachmentService) {
-        super("WALLET", redisTemplate, retryHelper, attachmentService);
+        super("WALLET", redisTemplate, retryHelper, attachmentService,
+                new TypeReference<WalletFullData>() {});
     }
 
     public WalletFullData getWalletDataWithSeqCheck(String key, int expectedSeq) {
@@ -33,6 +34,6 @@ public class WalletRedisClient extends AbstractRedisClient {
             }
             return new CheckResult(false, String.format("Sequence mismatch: current=%d, expected=%d", currentSeq, expectedSeq));
         };
-        return getWithCheck(key, new TypeReference<WalletFullData>() {}, checkFunc);
+        return getWithCheck(key, checkFunc);
     }
 }

--- a/src/test/java/com/uplatform/wallet_tests/tests/default_steps/steps/PlayerFullRegistrationStep.java
+++ b/src/test/java/com/uplatform/wallet_tests/tests/default_steps/steps/PlayerFullRegistrationStep.java
@@ -23,7 +23,6 @@ import com.uplatform.wallet_tests.api.kafka.dto.PlayerAccountMessage;
 import com.uplatform.wallet_tests.api.nats.dto.enums.NatsLimitIntervalType;
 import com.uplatform.wallet_tests.api.redis.client.PlayerRedisClient;
 import com.uplatform.wallet_tests.api.redis.client.WalletRedisClient;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.uplatform.wallet_tests.api.redis.model.WalletData;
 import com.uplatform.wallet_tests.api.redis.model.WalletFilterCriteria;
 import com.uplatform.wallet_tests.api.redis.model.WalletFullData;
@@ -301,8 +300,7 @@ public class PlayerFullRegistrationStep {
 
         step("Redis (Wallet): Получение и проверка полных данных кошелька", () -> {
             ctx.updatedWalletData = this.walletRedisClient.getWithRetry(
-                    ctx.playerWalletData.getWalletUUID(),
-                    new TypeReference<WalletFullData>() {});
+                    ctx.playerWalletData.getWalletUUID());
             assertNotNull(ctx.updatedWalletData, "redis.wallet.full_data_not_found");
             assertNotNull(ctx.updatedWalletData.getPlayerUUID(), "redis.wallet.player_uuid");
         });

--- a/src/test/java/com/uplatform/wallet_tests/tests/default_steps/steps/PlayerRegistrationStep.java
+++ b/src/test/java/com/uplatform/wallet_tests/tests/default_steps/steps/PlayerRegistrationStep.java
@@ -19,7 +19,6 @@ import com.uplatform.wallet_tests.api.kafka.client.PlayerAccountKafkaClient;
 import com.uplatform.wallet_tests.api.kafka.dto.PlayerAccountMessage;
 import com.uplatform.wallet_tests.api.redis.client.PlayerRedisClient;
 import com.uplatform.wallet_tests.api.redis.client.WalletRedisClient;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.uplatform.wallet_tests.api.redis.model.WalletData;
 import com.uplatform.wallet_tests.api.redis.model.WalletFilterCriteria;
 import com.uplatform.wallet_tests.api.redis.model.WalletFullData;
@@ -199,8 +198,7 @@ public class PlayerRegistrationStep {
 
         step("Redis (Wallet): Получение и проверка полных данных кошелька", () -> {
             ctx.updatedWalletData = this.walletRedisClient.getWithRetry(
-                    ctx.playerWalletData.getWalletUUID(),
-                    new TypeReference<WalletFullData>() {});
+                    ctx.playerWalletData.getWalletUUID());
             assertNotNull(ctx.updatedWalletData, "redis.wallet.full_data_not_found");
             assertNotNull(ctx.updatedWalletData.getPlayerUUID(), "redis.wallet.player_uuid");
         });


### PR DESCRIPTION
## Summary
- refactor AbstractRedisClient to be generic
- store TypeReference in Redis client constructor
- update PlayerRedisClient and WalletRedisClient
- adapt steps to new API
- update README for generic Redis client

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687bb37fcdf4832fbb239428d7f622b3