### PR TITLE
Add helper for Redis factory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,8 +356,9 @@ step("Kafka: получение сообщения", () -> {
 
 1. Добавьте параметры нового инстанса в `redis.instances` конфигурационного
    файла.
-2. В `RedisConfig` опишите бины `RedisProperties`, `LettuceConnectionFactory` и
-   `RedisTemplate` по образцу существующих.
+2. В `RedisConfig` создайте только бин `RedisProperties` и вызовите метод
+   `createRedisInfrastructure("bonus", bonusRedisProperties())` для получения
+   `RedisTemplate` и соответствующего `LettuceConnectionFactory`.
 3. Создайте клиент, расширяющий `AbstractRedisClient`.
 
 Пример фрагмента `RedisConfig` для инстанса `bonus`:
@@ -369,16 +370,10 @@ public RedisProperties bonusRedisProperties() {
     return new RedisProperties();
 }
 
-@Bean("bonusRedisConnectionFactory")
-public LettuceConnectionFactory bonusRedisConnectionFactory(
-        @Qualifier("bonusRedisProperties") RedisProperties properties) {
-    return createConnectionFactory(properties, bonusLettucePoolingConfig(properties));
-}
-
 @Bean("bonusRedisTemplate")
 public RedisTemplate<String, String> bonusRedisTemplate(
-        @Qualifier("bonusRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
-    return createStringRedisTemplate(connectionFactory);
+        @Qualifier("bonusRedisProperties") RedisProperties properties) {
+    return createRedisInfrastructure("bonus", properties);
 }
 ```
 


### PR DESCRIPTION
## Summary
- simplify RedisConfig by creating helper `createRedisInfrastructure`
- use this helper for player and wallet Redis templates
- update README to describe new helper usage

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4135774832fa186e82410b7d61f