### PR TITLE
Rename RedisConfig to RedisSettings

### DIFF
--- a/src/test/java/com/uplatform/wallet_tests/api/redis/client/RedisRetryHelper.java
+++ b/src/test/java/com/uplatform/wallet_tests/api/redis/client/RedisRetryHelper.java
@@ -34,7 +34,7 @@ public class RedisRetryHelper {
         RedisAggregateConfig aggregateConfig = Optional.ofNullable(configProvider)
                 .map(EnvironmentConfigurationProvider::getEnvironmentConfig)
                 .map(com.uplatform.wallet_tests.config.EnvironmentConfig::getRedis)
-                .map(com.uplatform.wallet_tests.config.RedisConfig::getAggregate)
+                .map(com.uplatform.wallet_tests.config.RedisSettings::getAggregate)
                 .orElseThrow(() -> new IllegalStateException(
                         "RedisAggregateConfig not found in EnvironmentConfigurationProvider. Cannot initialize RedisRetryHelper."));
 

--- a/src/test/java/com/uplatform/wallet_tests/config/DynamicPropertiesConfigurator.java
+++ b/src/test/java/com/uplatform/wallet_tests/config/DynamicPropertiesConfigurator.java
@@ -64,7 +64,7 @@ public class DynamicPropertiesConfigurator implements ApplicationContextInitiali
             });
         }
 
-        RedisConfig redisFullConfig = config.getRedis();
+        RedisSettings redisFullConfig = config.getRedis();
 
         if (redisFullConfig != null) {
             RedisAggregateConfig aggregateConfig = redisFullConfig.getAggregate();

--- a/src/test/java/com/uplatform/wallet_tests/config/EnvironmentConfig.java
+++ b/src/test/java/com/uplatform/wallet_tests/config/EnvironmentConfig.java
@@ -12,7 +12,7 @@ public class EnvironmentConfig {
     private ApiConfig api;
     private PlatformConfig platform;
     private Map<String, DatabaseInstanceConfig> databases;
-    private RedisConfig redis;
+    private RedisSettings redis;
     private KafkaConfig kafka;
     private NatsConfig nats;
 

--- a/src/test/java/com/uplatform/wallet_tests/config/RedisSettings.java
+++ b/src/test/java/com/uplatform/wallet_tests/config/RedisSettings.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import java.util.Map;
 
 @Data
-public class RedisConfig {
+public class RedisSettings {
     private RedisAggregateConfig aggregate;
     private Map<String, RedisInstanceConfig> instances;
 }


### PR DESCRIPTION
## Summary
- rename `RedisConfig` to `RedisSettings`
- update environment config and dynamic properties configurator
- update RedisRetryHelper to refer to the renamed class

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687bb45b5144832f8ad15c87269dc54c